### PR TITLE
Remove listPriceText from Shop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@epages/immutable-api-records",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@epages/immutable-api-records",
   "description": "ImmutableJS records for the new ePages REST API.",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "scripts": {
     "test": "npm run lint && npm run mocha",
     "build": "sh -c \"rm -rf build/ && NODE_ENV=production babel src/ --out-dir build/\"",

--- a/src/Shop.js
+++ b/src/Shop.js
@@ -18,7 +18,6 @@ const ShopRecord = new Record({
   vatExempted: null,
   closedByMerchant: false,
   closedShopMessage: null,
-  listPriceText: null,
   minimumOrderValue: null,
   _links: null,
   _embedded: new Map()


### PR DESCRIPTION
Using listPriceText from Shop is deprecated. The owner of this data is now ng-product-management, who is also responsible for sending it to ng-product-view.

I'm preparing a merchant-ui PR that depends on this PR.