### PR TITLE
New: Add manufacturer price

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@epages/immutable-api-records",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@epages/immutable-api-records",
   "description": "ImmutableJS records for the new ePages REST API.",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "scripts": {
     "test": "npm run lint && npm run mocha",
     "build": "sh -c \"rm -rf build/ && NODE_ENV=production babel src/ --out-dir build/\"",

--- a/src/Product.js
+++ b/src/Product.js
@@ -17,6 +17,7 @@ const ProductRecord = new Record({
   salesPrice: null,
   listPrice: null,
   onSale: null,
+  manufacturerPrice: null,
   refPrice: null,
   taxClass: null,
   manufacturer: null,
@@ -41,6 +42,7 @@ export default class Product extends ProductRecord {
       .update('_id', (id) => id || extractIdFromSelfLink(immutable))
       .update('salesPrice', (sp) => sp && new Price(sp))
       .update('listPrice', (lp) => lp && new Price(lp))
+      .update('manufacturerPrice', (mp) => mp && new Price(mp))
       .update('refPrice', (rp) => rp && new ReferencePrice(rp))
       .update('shippingPeriod', (sp) => sp && new ShippingPeriod(sp))
       .update('shippingDimension', (sd) => sd && new ShippingDimension(sd))


### PR DESCRIPTION
The `manufacturerPrice` is needed to implement this field in the product edit view. 
Related PR: https://github.com/ePages-de/ng-merchant-ui/pull/509