### PR TITLE
Update: Add invoice cancelation

### DIFF
--- a/src/OrderEvent.js
+++ b/src/OrderEvent.js
@@ -184,7 +184,7 @@ export default class OrderEvent extends OrderEventRecord {
           case 'shipping-pending': return new OrderEventShippingPendingDetails(d)
           case 'shipping-shipped': return new OrderEventShippingShippedDetails(d)
           case 'items-returned': return new OrderEventItemsReturnedDetails(d)
-          case 'invoice-correction-created': return new OrderEventInvoiceCancelationCreatedDetails(d)
+          case 'invoice-cancelation-created': return new OrderEventInvoiceCancelationCreatedDetails(d)
           default: return new OrderEventUnknownDetails(d)
         }
       })

--- a/src/OrderEvent.js
+++ b/src/OrderEvent.js
@@ -19,12 +19,22 @@ const OrderEventInvoiceCancelationCreatedDetailsRecord = new Record({
 
 export class OrderEventInvoiceCancelationCreatedDetails extends OrderEventInvoiceCancelationCreatedDetailsRecord {}
 
+const OrderEventInvoiceCorrectionDetailsRecord = new Record({
+  type: null,
+  previousInvoiceNumber: null,
+  invoicePdfUri: null,
+  newInvoiceNumber: null
+})
+
+export class OrderEventInvoiceCorrectionDetails extends OrderEventInvoiceCorrectionDetailsRecord {}
+
 const OrderEventShippingShippedDetailsRecord = new Record({
   type: null,
   trackingLink: null,
   lineItems: null,
   shippingProcessId: null
 })
+
 export class OrderEventShippingShippedDetails extends OrderEventShippingShippedDetailsRecord {
   constructor (orderEventShippingShippedDetails) {
     const immutable = Immutable.fromJS(orderEventShippingShippedDetails || {})
@@ -185,6 +195,7 @@ export default class OrderEvent extends OrderEventRecord {
           case 'shipping-shipped': return new OrderEventShippingShippedDetails(d)
           case 'items-returned': return new OrderEventItemsReturnedDetails(d)
           case 'invoice-cancelation-created': return new OrderEventInvoiceCancelationCreatedDetails(d)
+          case 'invoice-correction-created': return new OrderEventInvoiceCorrectionDetails(d)
           default: return new OrderEventUnknownDetails(d)
         }
       })

--- a/src/OrderEvent.js
+++ b/src/OrderEvent.js
@@ -11,6 +11,14 @@ const OrderEventCreatedDetailsRecord = new Record({
 export class OrderEventCreatedDetails extends OrderEventCreatedDetailsRecord {
 }
 
+const OrderEventInvoiceCancelationCreatedDetailsRecord = new Record({
+  type: null,
+  invoiceNumber: null,
+  invoicePdfUri: null
+})
+
+export class OrderEventInvoiceCancelationCreatedDetails extends OrderEventInvoiceCancelationCreatedDetailsRecord {}
+
 const OrderEventShippingShippedDetailsRecord = new Record({
   type: null,
   trackingLink: null,
@@ -176,6 +184,7 @@ export default class OrderEvent extends OrderEventRecord {
           case 'shipping-pending': return new OrderEventShippingPendingDetails(d)
           case 'shipping-shipped': return new OrderEventShippingShippedDetails(d)
           case 'items-returned': return new OrderEventItemsReturnedDetails(d)
+          case 'invoice-correction-created': return new OrderEventInvoiceCancelationCreatedDetails(d)
           default: return new OrderEventUnknownDetails(d)
         }
       })

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,8 @@ export {OrderEventPaymentVoidedDetails} from './OrderEvent'
 export {OrderEventUnknownDetails} from './OrderEvent'
 export {OrderEventShippingPendingDetails} from './OrderEvent'
 export {OrderEventShippingShippedDetails} from './OrderEvent'
+export {OrderEventInvoiceCancelationCreatedDetails} from './OrderEvent'
+export {OrderEventInvoiceCorrectionDetails} from './OrderEvent'
 
 export {OrderEventItemsCanceledDetails} from './OrderEvent'
 


### PR DESCRIPTION
I've just added two more classes to `orderEvents` so that `immutable-api-records` lets in the properties of the 'invoice-cancelation-created' and 'invoice-correction-created'.

ePages-de/ng-merchant-ui#785 depends on this PR.

EPNG-4580
