### PR TITLE
Update: Add OrderEventInvoiceCorrectionDetails

### DIFF
--- a/src/OrderEvent.js
+++ b/src/OrderEvent.js
@@ -11,6 +11,14 @@ const OrderEventCreatedDetailsRecord = new Record({
 export class OrderEventCreatedDetails extends OrderEventCreatedDetailsRecord {
 }
 
+const OrderEventInvoiceCreatedDetailsRecord = new Record({
+  type: null,
+  invoiceNumber: null,
+  invoicePdfUri: null
+})
+
+export class OrderEventInvoiceCreatedDetails extends OrderEventInvoiceCreatedDetailsRecord {}
+
 const OrderEventInvoiceCancelationCreatedDetailsRecord = new Record({
   type: null,
   invoiceNumber: null,
@@ -194,6 +202,7 @@ export default class OrderEvent extends OrderEventRecord {
           case 'shipping-pending': return new OrderEventShippingPendingDetails(d)
           case 'shipping-shipped': return new OrderEventShippingShippedDetails(d)
           case 'items-returned': return new OrderEventItemsReturnedDetails(d)
+          case 'invoice-created': return new OrderEventCreatedDetails(d)
           case 'invoice-cancelation-created': return new OrderEventInvoiceCancelationCreatedDetails(d)
           case 'invoice-correction-created': return new OrderEventInvoiceCorrectionDetails(d)
           default: return new OrderEventUnknownDetails(d)

--- a/src/OrderEvent.js
+++ b/src/OrderEvent.js
@@ -202,7 +202,7 @@ export default class OrderEvent extends OrderEventRecord {
           case 'shipping-pending': return new OrderEventShippingPendingDetails(d)
           case 'shipping-shipped': return new OrderEventShippingShippedDetails(d)
           case 'items-returned': return new OrderEventItemsReturnedDetails(d)
-          case 'invoice-created': return new OrderEventCreatedDetails(d)
+          case 'invoice-created': return new OrderEventInvoiceCreatedDetails(d)
           case 'invoice-cancelation-created': return new OrderEventInvoiceCancelationCreatedDetails(d)
           case 'invoice-correction-created': return new OrderEventInvoiceCorrectionDetails(d)
           default: return new OrderEventUnknownDetails(d)

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export {OrderEventPaymentVoidedDetails} from './OrderEvent'
 export {OrderEventUnknownDetails} from './OrderEvent'
 export {OrderEventShippingPendingDetails} from './OrderEvent'
 export {OrderEventShippingShippedDetails} from './OrderEvent'
+export {OrderEventInvoiceCreatedDetails} from './OrderEvent'
 export {OrderEventInvoiceCancelationCreatedDetails} from './OrderEvent'
 export {OrderEventInvoiceCorrectionDetails} from './OrderEvent'
 


### PR DESCRIPTION
Also is related to https://github.com/ePages-de/ng-merchant-ui/pull/785, we also just show the invoice-created bullet.

![Screenshot from 2019-10-14 16-54-14](https://user-images.githubusercontent.com/17606011/66760911-47037680-eea3-11e9-86d9-653fe53092d6.png)


EPNG-4580